### PR TITLE
[Fix] rubocopの導入によるビルドエラーの修正

### DIFF
--- a/app/graphql/types/node_type.rb
+++ b/app/graphql/types/node_type.rb
@@ -1,6 +1,5 @@
 module Types
   module NodeType
-    description 'Node'
     include Types::BaseInterface
     # Add the `id` field
     include GraphQL::Types::Relay::NodeBehaviors

--- a/bin/bundle
+++ b/bin/bundle
@@ -9,7 +9,7 @@
 #
 # rubocop:disable all
 
-require 'rubygems'
+require "rubygems"
 
 m = Module.new do
   module_function
@@ -19,13 +19,12 @@ m = Module.new do
   end
 
   def env_var_version
-    ENV.fetch('BUNDLER_VERSION', nil)
+    ENV["BUNDLER_VERSION"]
   end
 
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
-    return unless 'update'.start_with?(ARGV.first || ' ') # must be running `bundle update`
-
+    return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
     bundler_version = nil
     update_index = nil
     ARGV.each_with_index do |a, i|
@@ -33,24 +32,23 @@ m = Module.new do
         bundler_version = a
       end
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-
-      bundler_version = Regexp.last_match(1)
+      bundler_version = $1
       update_index = i
     end
     bundler_version
   end
 
   def gemfile
-    gemfile = ENV.fetch('BUNDLE_GEMFILE', nil)
-    return gemfile if gemfile.present?
+    gemfile = ENV["BUNDLE_GEMFILE"]
+    return gemfile if gemfile && !gemfile.empty?
 
-    File.expand_path('../Gemfile', __dir__)
+    File.expand_path("../../Gemfile", __FILE__)
   end
 
   def lockfile
     lockfile =
       case File.basename(gemfile)
-      when 'gems.rb' then gemfile.sub(/\.rb$/, gemfile)
+      when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)
       else "#{gemfile}.lock"
       end
     File.expand_path(lockfile)
@@ -58,54 +56,48 @@ m = Module.new do
 
   def lockfile_version
     return unless File.file?(lockfile)
-
     lockfile_contents = File.read(lockfile)
     return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
-
     Regexp.last_match(1)
   end
 
   def bundler_requirement
     @bundler_requirement ||=
       env_var_version || cli_arg_version ||
-      bundler_requirement_for(lockfile_version)
+        bundler_requirement_for(lockfile_version)
   end
 
   def bundler_requirement_for(version)
     return "#{Gem::Requirement.default}.a" unless version
-
     bundler_gem_version = Gem::Version.new(version)
 
     requirement = bundler_gem_version.approximate_recommendation
 
-    return requirement unless Gem.rubygems_version < Gem::Version.new('2.7.0')
+    return requirement unless Gem.rubygems_version < Gem::Version.new("2.7.0")
 
-    requirement += '.a' if bundler_gem_version.prerelease?
+    requirement += ".a" if bundler_gem_version.prerelease?
 
     requirement
   end
 
   def load_bundler!
-    ENV['BUNDLE_GEMFILE'] ||= gemfile
+    ENV["BUNDLE_GEMFILE"] ||= gemfile
 
     activate_bundler
   end
 
   def activate_bundler
     gem_error = activation_error_handling do
-      gem 'bundler', bundler_requirement
+      gem "bundler", bundler_requirement
     end
     return if gem_error.nil?
-
     require_error = activation_error_handling do
-      require 'bundler/version'
+      require "bundler/version"
     end
     return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
-
     warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end
-
   def activation_error_handling
     yield
     nil
@@ -113,9 +105,8 @@ m = Module.new do
     e
   end
 end
-
 m.load_bundler!
 
 if m.invoked_as_script?
-  load Gem.bin_path('bundler', 'bundle')
+  load Gem.bin_path("bundler", "bundle")
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -7,7 +7,6 @@
 # The application 'bundle' is installed as part of a gem, and
 # this file is here to facilitate running it.
 #
-
 # rubocop:disable all
 
 require 'rubygems'
@@ -16,7 +15,7 @@ m = Module.new do
   module_function
 
   def invoked_as_script?
-    File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
+    File.expand_path($0) == File.expand_path(__FILE__)
   end
 
   def env_var_version

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV.fetch('FRONTEND_URL', nil)
+    origins Regexp.new(ENV.fetch('FRONTEND_URL', nil))
 
     resource '*',
              headers: :any,


### PR DESCRIPTION
bin/bundle をrubocopに従って修正を加えたところherokuでのビルドエラーが起きたため
初期の状態に戻し、rubocopの監視から外すことで修正